### PR TITLE
Handle carriage return in ZSH regex

### DIFF
--- a/shell-matcher.js
+++ b/shell-matcher.js
@@ -1,5 +1,5 @@
 
 exports.sh = /(?:ba)?sh: ((?:file:\/\/)|(?:\/\/))?(.*): (?:(?:command not found)|(?:No such file or directory))/;
 exports.bash = exports.sh;
-exports.zsh = /zsh: (?:(?:command not found)|(?:no such file or directory)): ((?:file:\/\/)|(?:\/\/))?([^\n]+)/;
+exports.zsh = /zsh: (?:(?:command not found)|(?:no such file or directory)): ((?:file:\/\/)|(?:\/\/))?([^\r\n]+)/;
 exports.fish = /fish: Unknown command '((?:file:\/\/)|(?:\/\/))?([^']+)'/;


### PR DESCRIPTION
For some reason my zsh prompt produces a `\r`after commands, which makes the markdown regex [here](https://github.com/elmasse/hyper-markdown-preview/blob/master/index.js#L32) fail. A bit weird since I'm using macOS, but this fixes it at least.

Great plugin by the way :)